### PR TITLE
Minimum stability usage linter

### DIFF
--- a/src/Linter.php
+++ b/src/Linter.php
@@ -19,6 +19,7 @@ final class Linter
     {
         $defaultConfig = array(
             'php' => true,
+            'minimum-stability' => true,
         );
 
         $this->config = array_merge($defaultConfig, $config);
@@ -51,6 +52,11 @@ final class Linter
             } elseif (!$isOnRequire) {
                 array_push($errors, 'You must specifiy the PHP requirement.');
             }
+        }
+
+        if (true === $this->config['minimum-stability'] && array_key_exists('minimum-stability', $manifest) &&
+            array_key_exists('type', $manifest) && 'project' !== $manifest['type']) {
+            array_push($errors, 'The minimum-stability should be only used for project packages.');
         }
 
         return $errors;

--- a/tests/LinterTest.php
+++ b/tests/LinterTest.php
@@ -43,6 +43,10 @@ final class LinterTest extends \PHPUnit_Framework_TestCase
             array(__DIR__.'/fixtures/php-ko.json', 1),
             array(__DIR__.'/fixtures/php-on-dev.json', 1),
             array(__DIR__.'/fixtures/php-ko-disabled.json'),
+            array(__DIR__.'/fixtures/minimum-stability-ok.json'),
+            array(__DIR__.'/fixtures/minimum-stability-ko.json', 1),
+            array(__DIR__.'/fixtures/minimum-stability-project.json'),
+            array(__DIR__.'/fixtures/minimum-stability-ko-disabled.json'),
         );
     }
 }

--- a/tests/fixtures/minimum-stability-ko-disabled.json
+++ b/tests/fixtures/minimum-stability-ko-disabled.json
@@ -1,0 +1,12 @@
+{
+    "type": "library",
+    "require": {
+        "php": "^5.3"
+    },
+    "minimum-stability": "dev",
+    "config": {
+        "sllh-composer-lint": {
+            "minimum-stability": false
+        }
+    }
+}

--- a/tests/fixtures/minimum-stability-ko.json
+++ b/tests/fixtures/minimum-stability-ko.json
@@ -1,0 +1,7 @@
+{
+    "type": "library",
+    "require": {
+        "php": "^5.3"
+    },
+    "minimum-stability": "dev"
+}

--- a/tests/fixtures/minimum-stability-ok.json
+++ b/tests/fixtures/minimum-stability-ok.json
@@ -1,0 +1,6 @@
+{
+    "type": "library",
+    "require": {
+        "php": "^5.3"
+    }
+}

--- a/tests/fixtures/minimum-stability-project.json
+++ b/tests/fixtures/minimum-stability-project.json
@@ -1,0 +1,7 @@
+{
+    "type": "project",
+    "require": {
+        "php": "^5.3"
+    },
+    "minimum-stability": "dev"
+}


### PR DESCRIPTION
This will prevent minimum-stability key usage if your package is not a project.
