### PR TITLE
minimum-stability: made message meaning clearer

### DIFF
--- a/src/Linter.php
+++ b/src/Linter.php
@@ -63,7 +63,7 @@ final class Linter
 
         if (true === $this->config['minimum-stability'] && array_key_exists('minimum-stability', $manifest) &&
             array_key_exists('type', $manifest) && 'project' !== $manifest['type']) {
-            array_push($errors, 'The minimum-stability should be only used for project packages.');
+            array_push($errors, 'The minimum-stability should be only used for packages of type "project".');
         }
 
         if (true === $this->config['version-constraints']) {


### PR DESCRIPTION
Caveat: When looking at the [Composer code](https://github.com/composer/composer), I could not find a clear indicator that `minimum-stability` is not used for operations that affect libraries. For example, I can imagine that a `composer require some/thing --no-update` will consider the `minimum-stability` when adding a line to the `composer.json` of a library. I just don't know enough about Composer to judge that.