### PR TITLE
fix(deps): allow Composer 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,14 @@ cache:
 
 before_install:
   - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - composer global require 'phpunit/phpunit:<6' satooshi/php-coveralls:@stable --no-update
+  - composer global require php-coveralls/php-coveralls:@stable --no-update
   - if [ "$COMPOSER_VERSION" != "" ]; then composer require "composer/composer:${COMPOSER_VERSION}" --no-update; fi;
 
 install:
   - composer global update --prefer-dist --no-interaction
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+  - vendor/bin/simple-phpunit install
 
-script: phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
+script: vendor/bin/simple-phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
 
 after_script: coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.0 || ^2.0",
-        "symfony/phpunit-bridge": "^2.7.4 || ^3.0"
+        "symfony/phpunit-bridge": "^5.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.0",
+        "composer/composer": "^1.0 || ^2.0",
         "symfony/phpunit-bridge": "^2.7.4 || ^3.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,8 @@
          syntaxCheck="false">
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <!-- PHPUnit version 5 because we still allow PHP 5.6 -->
+        <env name="SYMFONY_PHPUNIT_VERSION" value="5" />
     </php>
 
     <testsuites>
@@ -25,4 +27,8 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/tests/LintPluginTest.php
+++ b/tests/LintPluginTest.php
@@ -12,6 +12,7 @@ use Composer\Plugin\CommandEvent;
 use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Composer\Plugin\PluginManager;
+use PHPUnit\Framework\TestCase;
 use SLLH\ComposerLint\LintPlugin;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -19,7 +20,7 @@ use Symfony\Component\Console\Output\NullOutput;
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class LintPluginTest extends \PHPUnit_Framework_TestCase
+final class LintPluginTest extends TestCase
 {
     /**
      * @var BufferIO

--- a/tests/LinterTest.php
+++ b/tests/LinterTest.php
@@ -3,12 +3,13 @@
 namespace SLLH\ComposerLint\Tests;
 
 use Composer\Json\JsonFile;
+use PHPUnit\Framework\TestCase;
 use SLLH\ComposerLint\Linter;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class LinterTest extends \PHPUnit_Framework_TestCase
+final class LinterTest extends TestCase
 {
     /**
      * @dataProvider getLintData


### PR DESCRIPTION
Hi,

It seems that updating constraints version has been forgotten in #15, now GitHub Actions and Travis builds are failing because they use Composer v2 by default, see https://travis-ci.org/github/Algatux/influxdb-bundle/jobs/740050254.

I've also updated PHPUnit tests and used Symfony Bridge to install PHPUnit, because tests were failing due to the PHPUnit version. It seems that `composer global require 'phpunit/phpunit:<6'` was not doing anything since it installed PHPUnit 7+, see https://travis-ci.org/github/soullivaneuh/composer-lint/jobs/740117964

Thanks! 